### PR TITLE
Fix pyzx version at 0.8.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyzx>=0.8.0  # or use pyzx@git+https://github.com/Quantomatic/pyzx for latest development version
+pyzx~=0.8.0  # or use pyzx@git+https://github.com/Quantomatic/pyzx for latest development version
 matplotlib>=3.7.4
 numpy>=1.24.0,<2  # can't go higher than 1.24.0 for python 3.8
 pylatexenc~=2.10


### PR DESCRIPTION
A change after this version enforces that `phase` is a `Fraction` with an `assert`, which breaks `test_random_circuits` as it sometimes produces a `phase` which is a floating point value.